### PR TITLE
Speed up workflows

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -52,7 +52,7 @@ jobs:
           cd library/
           for subpackage in ${{ env.subpackages }}; do
             cd wumpy-$subpackage/
-            flit install --extras all
+            flit install --extras all --pth-file
             cd ..
           done
           cd ..
@@ -147,7 +147,7 @@ jobs:
           cd library/
           for subpackage in ${{ env.subpackages }}; do
             cd wumpy-$subpackage/
-            flit install --extras all
+            flit install --extras all --pth-file
             cd ..
           done
           cd ..
@@ -196,7 +196,7 @@ jobs:
           cd library/
           for subpackage in ${{ env.subpackages }}; do
             cd wumpy-$subpackage/
-            flit install --extras all
+            flit install --extras all --pth-file
             cd ..
           done
           cd ..


### PR DESCRIPTION
## Summary

Currently, there are a handful steps in the Test and Lint workflow that take up to a minute (installing the subpackages). This pull request is a playground of different fixes, and seeing how they affect runtime.
