### PR TITLE
Fix recently introduced test failures

### DIFF
--- a/library/wumpy-bot/wumpy/bot/extension.py
+++ b/library/wumpy-bot/wumpy/bot/extension.py
@@ -4,6 +4,7 @@ import sys
 from typing import Any, Callable, Dict, Optional, Union
 
 from wumpy.interactions import CommandRegistrar
+from wumpy.interactions.commands.slash import SubcommandGroup
 
 from .dispatch import EventDispatcher
 from .errors import ExtensionFailure
@@ -61,7 +62,7 @@ class Extension(CommandRegistrar, EventDispatcher):
                     target.add_listener(callback)
 
         if isinstance(target, CommandRegistrar):
-            for command in self.commands.values():
+            for command in self._commands.values():
                 target.add_command(command)
 
         self._data = data
@@ -75,7 +76,7 @@ class Extension(CommandRegistrar, EventDispatcher):
                     target.remove_listener(callback, event=annotation)
 
         if isinstance(target, CommandRegistrar):
-            for command in self.commands.values():
+            for command in self._commands.values():
                 target.remove_command(command)
 
 
@@ -108,8 +109,11 @@ class ExtensionLoader(CommandRegistrar, EventDispatcher):
                 if _is_submodule(callback.__module__, module):
                     self.remove_listener(callback, event=annotation)
 
-        for command in self.commands.values():
-            if _is_submodule(command.callback.__module__, module):
+        for command in self._commands.values():
+            if (
+                    not isinstance(command, SubcommandGroup)
+                    and _is_submodule(command.callback.__module__, module)
+            ):
                 self.remove_command(command)
 
     def load_extension(self, path: str, package: Optional[str] = None, **kwargs: Any) -> None:

--- a/library/wumpy-interactions/wumpy/interactions/commands/registrar.py
+++ b/library/wumpy-interactions/wumpy/interactions/commands/registrar.py
@@ -158,7 +158,7 @@ def command(
 class CommandRegistrar:
     """Root registrar of command handlers."""
 
-    _commands: Dict[str, CommandUnion['...', object]]
+    _commands: Dict[str, 'CommandUnion[..., object]']
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -194,7 +194,7 @@ class CommandRegistrar:
 
         self._commands[command.name] = command
 
-    def get_command(self, name: str) -> Optional[CommandUnion['...', object]]:
+    def get_command(self, name: str) -> Optional['CommandUnion[..., object]']:
         """Get a registered command from the registrar.
 
         Parameters:

--- a/tests/wumpy-interactions/commands/test_context.py
+++ b/tests/wumpy-interactions/commands/test_context.py
@@ -15,7 +15,7 @@ class TestContextCommand:
         async def test(interaction, argument):
             ...
 
-        assert registrar.commands['test'] == test
+        assert registrar.get_command('test') == test
 
     def test_non_async(self, commandtype: CommandType):
         registrar = CommandRegistrar()


### PR DESCRIPTION
## Summary

There were several test failures accidentally introduced in e7dfe77d610dd9a99b7af606e50a1c6e8479c9c2 which this PR aims to fix.

The change of quoting for ellipsis appears to be a bug in the typing module which wasn't accounted for.
