### PR TITLE
Work on getting tests/CI to run again

### DIFF
--- a/library/wumpy-bot/wumpy/bot/dispatch.py
+++ b/library/wumpy-bot/wumpy/bot/dispatch.py
@@ -2,7 +2,9 @@ import dataclasses
 import inspect
 from abc import abstractmethod
 from functools import partial
-from typing import (
+# Coroutine is used inside of a string TypeAlias, which flake8 doesn't
+# understand at the moment so we need to silence it
+from typing import (  # noqa: F401
     Any, Callable, ClassVar, Coroutine, Dict, List, Mapping, Optional, Type,
     TypeVar, Union, overload
 )

--- a/library/wumpy-bot/wumpy/bot/events/guild.py
+++ b/library/wumpy-bot/wumpy/bot/events/guild.py
@@ -5,13 +5,13 @@ from discord_typings import (
     GuildBanAddData, GuildBanRemoveData, GuildDeleteData,
     GuildEmojisUpdateData, GuildMemberAddData, GuildMemberRemoveData,
     GuildMemberUpdateData, GuildRoleCreateData, GuildRoleDeleteData,
-    GuildRoleUpdateData, GuildStickersUpdateData
+    GuildStickersUpdateData
 )
 from typing_extensions import Self
 from wumpy.models import Emoji, Guild, Member, Role, Snowflake, Sticker, User
 
 from ..dispatch import Event
-from ..utils import _get_as_snowflake, backport_slots
+from ..utils import backport_slots
 
 
 @backport_slots()

--- a/library/wumpy-cache/wumpy/cache/protocol.py
+++ b/library/wumpy-cache/wumpy/cache/protocol.py
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Any, Dict, Optional, SupportsInt, Tuple, Type, Union
+from typing import Any, Dict, Optional, SupportsInt, Type, Union
 
 from typing_extensions import Protocol, Self
 from wumpy.models import (

--- a/library/wumpy-gateway/wumpy/gateway/shard.py
+++ b/library/wumpy-gateway/wumpy/gateway/shard.py
@@ -5,9 +5,7 @@ from contextlib import AsyncExitStack
 from functools import partial
 from sys import platform
 from types import TracebackType
-from typing import (
-    Any, AsyncContextManager, Callable, Deque, Dict, Optional, Tuple, Type
-)
+from typing import Any, Deque, Dict, Optional, Tuple, Type
 
 import anyio
 import anyio.abc

--- a/library/wumpy-interactions/wumpy/interactions/commands/base.py
+++ b/library/wumpy-interactions/wumpy/interactions/commands/base.py
@@ -20,7 +20,7 @@ class CommandCallback(Generic[P, RT]):
     """Asynchronous callback wrapped with processing.
 
     This class is used to wrap, store, and process a callback.
-    
+
     To use it, subclass and override the methods below. They are marked
     internal as to not leak out to the user since they are only meant to be
     called by this class.

--- a/library/wumpy-interactions/wumpy/interactions/commands/checks.py
+++ b/library/wumpy-interactions/wumpy/interactions/commands/checks.py
@@ -1,11 +1,12 @@
 import time
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, Callable, Dict, Hashable, List, Protocol, TypeVar
+from typing import Any, Callable, Dict, Hashable, List, TypeVar
 from weakref import WeakValueDictionary
 
 import anyio
 import anyio.lowlevel
+from typing_extensions import Protocol
 from wumpy.models import CommandInteractionOption
 
 from ..models import CommandInteraction

--- a/library/wumpy-interactions/wumpy/interactions/components/handler.py
+++ b/library/wumpy-interactions/wumpy/interactions/components/handler.py
@@ -10,7 +10,7 @@ __all__ = ['ComponentHandler']
 
 
 ComponentCallback = Callable[
-    [ComponentInteraction, re.Match],
+    [ComponentInteraction, 're.Match[str]'],
     Coroutine[Any, Any, object]
 ]
 
@@ -21,7 +21,7 @@ class ComponentHandler(ErrorHandlerMixin):
     This is a mixin class keeping track of handlers for components setup.
     """
 
-    _components: List[Tuple[re.Pattern, ComponentCallback]]
+    _components: List[Tuple['re.Pattern[str]', ComponentCallback]]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -32,7 +32,7 @@ class ComponentHandler(ErrorHandlerMixin):
             self,
             callback: ComponentCallback,
             interaction: ComponentInteraction,
-            match: re.Match
+            match: 're.Match[str]'
     ) -> None:
         try:
             await callback(interaction, match)
@@ -49,7 +49,7 @@ class ComponentHandler(ErrorHandlerMixin):
                 if match:
                     tg.start_soon(self._wrap_regex_callback, callback, interaction, match)
 
-    def add_component(self, pattern: re.Pattern, func: ComponentCallback) -> None:
+    def add_component(self, pattern: 're.Pattern[str]', func: ComponentCallback) -> None:
         """Add a callback to be dispatched when the pattern is matched.
 
         Parameters:
@@ -58,7 +58,7 @@ class ComponentHandler(ErrorHandlerMixin):
         """
         self._components.append((pattern, func))
 
-    def remove_component(self, pattern: re.Pattern, func: ComponentCallback) -> None:
+    def remove_component(self, pattern: 're.Pattern[str]', func: ComponentCallback) -> None:
         """Remove a callback from the list of components.
 
         Parameters:
@@ -75,7 +75,7 @@ class ComponentHandler(ErrorHandlerMixin):
 
     def component(
             self,
-            pattern: Union[str, re.Pattern]
+            pattern: Union[str, 're.Pattern[str]']
     ) -> Callable[[ComponentCallback], ComponentCallback]:
         """Add a callback to be dispatched when the custom ID is matched.
 

--- a/library/wumpy-rest/wumpy/rest/ratelimiter.py
+++ b/library/wumpy-rest/wumpy/rest/ratelimiter.py
@@ -4,14 +4,14 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import TracebackType
 from typing import (
-    Any, AsyncContextManager, AsyncGenerator, Awaitable, Callable, Dict,
-    Mapping, Optional, Protocol, Type
+    AsyncContextManager, AsyncGenerator, Awaitable, Callable, Dict,
+    Mapping, Optional, Type
 )
 from weakref import WeakValueDictionary
 
 import anyio
 import anyio.lowlevel
-from typing_extensions import Self
+from typing_extensions import Protocol, Self
 
 from .config import RatelimiterContext
 from .errors import RateLimited, ServerException

--- a/library/wumpy-rest/wumpy/rest/ratelimiter.py
+++ b/library/wumpy-rest/wumpy/rest/ratelimiter.py
@@ -4,8 +4,8 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import TracebackType
 from typing import (
-    AsyncContextManager, AsyncGenerator, Awaitable, Callable, Dict,
-    Mapping, Optional, Type
+    AsyncContextManager, AsyncGenerator, Awaitable, Callable, Dict, Mapping,
+    Optional, Type
 )
 from weakref import WeakValueDictionary
 


### PR DESCRIPTION
## Summary

This draft PR will work on getting all CI checks to run again after they have been failing from (previously) unreleased `discord_typings` imports.
